### PR TITLE
linux: bump Amlogic to Linux 5.13.y kernel

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -16,8 +16,8 @@ PKG_PATCH_DIRS="${LINUX}"
 
 case "${LINUX}" in
   amlogic)
-    PKG_VERSION="9f4ad9e425a1d3b6a34617b8ea226d56a119a717" # 5.12.0
-    PKG_SHA256="01d21177e389906349ff44257f7dbfb3aa503f970237e5da7d150566092b8120"
+    PKG_VERSION="62fb9874f5da54fdb243003b386128037319b219" # 5.13.0
+    PKG_SHA256="93dd5bf5e45dc6087ced72f5af4ea280c6b87ca72b94c91673155a316b9d275d"
     PKG_URL="https://github.com/torvalds/linux/archive/${PKG_VERSION}.tar.gz"
     PKG_SOURCE_NAME="linux-${LINUX}-${PKG_VERSION}.tar.gz"
     ;;


### PR DESCRIPTION
Hi @chewitt 

there are a couple of patches that need your eye cast over them:

- projects/Amlogic/patches/linux/amlogic-0024-FROMLIST-v1-usb-dwc3-meson-g12a-fix-shared-reset-con.patch
Updated the 2 lines (err_disable_clks to err_disable_regulator) in line with the remaining patch

- projects/Amlogic/patches/linux/amlogic-0013-FROMGIT-arm64-dts-amlogic-misc-DT-schema-fixups.patch
This is the remaining documentation section of the patch that is not yet in upstream.

I have run this on `PROJECT=Amlogic ARCH=aarch64 DEVICE=AMLG12 UBOOT_SYSTEM=odroid-n2 make image`

I have not yet updated the .config, but will.